### PR TITLE
Trim reflected column names

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .idea/
-
 _venv/
+/venv/
+/test.cfg

--- a/README.md
+++ b/README.md
@@ -1,1 +1,14 @@
 # sqlalchemy-firebird
+
+An external SQLAlchemy dialect for Firebird.
+
+This will replace SQLAlchemy's internal Firebird dialect which is not being maintained.
+
+Sample connection URI:
+
+```
+firebird2://sysdba:scott_tiger@localhost//home/gord/git/sqlalchemy-firebird/sqla_test.fdb
+```
+
+The dialect identifier is currently "firebird2" to avoid conflicts with the internal dialect.
+Eventually both `firebird://` and `firebird2://` will be equivalent.

--- a/sqlalchemy_firebird/base.py
+++ b/sqlalchemy_firebird/base.py
@@ -788,7 +788,7 @@ class FBDialect(default.DefaultDialect):
     def get_columns(self, connection, table_name, schema=None, **kw):
         # Query to extract the details of all the fields of the given table
         tblqry = """
-        SELECT r.rdb$field_name AS fname,
+        SELECT TRIM(r.rdb$field_name) AS fname,
                         r.rdb$null_flag AS null_flag,
                         t.rdb$type_name AS ftype,
                         f.rdb$field_sub_type AS stype,


### PR DESCRIPTION
`get_columns` was returning field names with trailing spaces, causing expressions like `table_a.c.ID` to fail with a KeyError because the field name was `'ID      '`, not `'ID'`. Fixes test failures in "BuggyDomainReflectionTest".

This PR also includes the changes from #1 