### PR TITLE
Apply remaining changes for ComponentReflectionTest

### DIFF
--- a/sqlalchemy_firebird/__init__.py
+++ b/sqlalchemy_firebird/__init__.py
@@ -20,6 +20,7 @@ from .base import TIMESTAMP
 from .base import VARCHAR
 from . import base  # noqa
 from . import fdb  # noqa
+from . import provision  # noqa
 # Not supporting kinterbase
 # from . import kinterbasdb  # noqa
 

--- a/sqlalchemy_firebird/provision.py
+++ b/sqlalchemy_firebird/provision.py
@@ -1,0 +1,9 @@
+from sqlalchemy.testing.provision import temp_table_keyword_args
+
+
+@temp_table_keyword_args.for_db("firebird2")
+def _firebird_temp_table_keyword_args(cfg, eng):
+    return {
+        "prefixes": ["GLOBAL TEMPORARY"],
+        "oracle_on_commit": "PRESERVE ROWS",
+    }

--- a/sqlalchemy_firebird/requirements.py
+++ b/sqlalchemy_firebird/requirements.py
@@ -5,9 +5,19 @@ from sqlalchemy.testing import exclusions
 
 class Requirements(SuiteRequirements):
     @property
-    def temp_table_reflection(self):
-        """Target database supports CREATE TEMPORARY TABLE."""
-        # For now, skip these tests until we see how
-        # https://github.com/sqlalchemy/sqlalchemy/issues/5085
-        # plays out.
+    def implicitly_named_constraints(self):
+        """target database supports constraints without an explicit name."""
+        return exclusions.open()
+
+    @property
+    def indexes_with_ascdesc(self):
+        """target database supports CREATE INDEX with column-level ASC/DESC."""
+        return exclusions.closed()
+
+    @property
+    def temp_table_names(self):
+        return exclusions.open()
+
+    @property
+    def unique_constraint_reflection(self):
         return exclusions.closed()


### PR DESCRIPTION
After merging these changes and updating SQLAlchemy to the current master branch ...

```
python -m pip install --upgrade git+https://github.com/sqlalchemy/sqlalchemy.git
```

... there should be no more failures when running the tests in ComponentReflectionTest, i.e.,

```
py.test -k ComponentReflectionTest --db firebird2
```
