### PR TITLE
Suppress pytest warning after code reformat

### DIFF
--- a/test/conftest.py
+++ b/test/conftest.py
@@ -1,7 +1,9 @@
 from sqlalchemy.dialects import registry
 import pytest
-from sqlalchemy.testing.plugin.pytestplugin import *
 
 registry.register("firebird2", "sqlalchemy_firebird.fdb", "FBDialect_fdb")
 
 pytest.register_assert_rewrite("sqlalchemy.testing.assertions")
+
+# this happens after pytest.register_assert_rewrite to avoid pytest warning
+from sqlalchemy.testing.plugin.pytestplugin import *


### PR DESCRIPTION
Moved the `from ... import ...` back to its previous position to suppress a pytest warning. After moving the line down I ran black on the file and it didn't complain, but then again I've never used black before.