### PR TITLE
Add requirement for failing rowcount test

### DIFF
--- a/sqlalchemy_firebird/requirements.py
+++ b/sqlalchemy_firebird/requirements.py
@@ -43,6 +43,10 @@ class Requirements(SuiteRequirements):
         return exclusions.closed()
 
     @property
+    def sane_rowcount_w_returning(self):
+        return exclusions.closed()
+
+    @property
     def temp_table_names(self):
         return exclusions.open()
 


### PR DESCRIPTION
Mike just moved test_rowcount.py into the test
suite and one test was failing. Add requirement
to skip that test.