### PR TITLE
Add unicode_ddl requirement

### DIFF
--- a/sqlalchemy_firebird/requirements.py
+++ b/sqlalchemy_firebird/requirements.py
@@ -60,6 +60,11 @@ class Requirements(SuiteRequirements):
         return exclusions.open()
 
     @property
+    def unicode_ddl(self):
+        # assumes ?charset=UTF8 in connection URI
+        return exclusions.open()
+
+    @property
     def unique_constraint_reflection(self):
         # TODO: Research ways to support this in Firebird
         return exclusions.closed()


### PR DESCRIPTION
[This SQLAlchemy commit](https://github.com/sqlalchemy/sqlalchemy/commit/bebd757b06f10f29f9e3555dc0a3ba6fe3ec93d5) made Unicode DDL tests available to external dialects. This PR enables those tests here.